### PR TITLE
Add Vue.js Japan User Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -3678,3 +3678,7 @@ A simple End of Day (EOD) update generator that helps you create a summary of yo
 ### Pallets
 The Pallets organization develops and supports popular Python frameworks and libraries, including Flask, Jinja, Click, and Quart. These libraries power applications of all sizes around the world and are downloaded millions of times each month. The goal of Pallets is to grow the community around these projects to create a sustainable group of contributors and users.
 https://palletsprojects.com
+
+### Vue.js Japan User Group
+The Vue.js Japan User Group (Japanese: Vue.js 日本ユーザーグループ) is a nonprofit organization to hold an annual Tech Conference about Vue.js, Vue related ecosystem and OSS related to Evan you in Japan.
+https://vuefes.jp/

--- a/README.md
+++ b/README.md
@@ -3681,4 +3681,5 @@ https://palletsprojects.com
 
 ### Vue.js Japan User Group
 The Vue.js Japan User Group (Japanese: Vue.js 日本ユーザーグループ) is a nonprofit organization to hold an annual Tech Conference about Vue.js, Vue related ecosystem and OSS related to Evan you in Japan.
-https://vuefes.jp/
+- Conference Web Site: https://vuefes.jp/
+- Organization Web Site: https://vuejs-jp.org/en


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL
<!--
  Make sure you create an account before applying. Don't have one?
  https://start.1password.com/signup/?t=B
  
  Example: myteam.1password.com
-->

vuejs-jp.1password.com

#### Project Name
<!--
  If this is for a team that works on multiple projects, a team name
  can be used instead.
-->

Vue.js Japan User Group

#### Short Description

The Vue.js Japan User Group (Japanese: Vue.js 日本ユーザーグループ) is a nonprofit organization to hold an annual Tech Conference about Vue.js, Vue related ecosystem and OSS related to Evan you in Japan.

#### Project Age
<!--
  Your project needs to be active and at least 30 days old to be
  eligible for this program.
-->

9 years

#### Number Of Core Contributors

50

#### Project Website

Organization Web Site: https://vuejs-jp.org/en
Conference Web Site: https://vuefes.jp/

#### Repository URL(s)

- Latest repository: https://github.com/vuejs-jp/vuefes-2023

#### Latest Release URL(s)

- Blog Site: https://note.com/moe6811/n/nf43e73473bcf?magazine_key=mb35849fee631
- X (Twitter): https://twitter.com/vuefes/status/1774999957550108674

#### License
<!--
  Please include the type (e.g. MIT, BSD, GPL, etc.), and a link
  to where it can be found in your repository.
-->

MIT License

## A Bit About Yourself

#### Name

Kazuya Kawaguchi

#### Email
<!-- We will use this to validate the application with your account -->

vuefes@gmail.com

#### Project Role

Lead of Vue.js conference, meetup and community operation team

#### Profile/Website
<!-- Link to GitHub profile page, project page bio, etc. -->

- https://github.com/kazupon
- https://twitter.com/kazu_pon

#### Anything else to add?

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [x] Yes, I'm open.
